### PR TITLE
Non-specified types

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Examples:
     // ESM
     import * as http from 'http';
     import { Server } from "socket.io";
-    import { eiows } from 'eiows';
+    import eiows from 'eiows';
 
     let server = http.createServer();
 

--- a/dist/wrapper.mjs
+++ b/dist/wrapper.mjs
@@ -1,2 +1,2 @@
 import eiows from './eiows.js'; 
-export { eiows };
+export default eiows;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./dist/wrapper.mjs",
-      "require": "./dist/eiows.js"
+      "require": "./dist/eiows.js",
+      "types": "./dist/eiows.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
There are types at '/home/ashu/Documents/GitHub/Fragment-source/core/node_modules/eiows/dist/eiows.d.ts', but this result could not be resolved when respecting package.json "exports". The 'eiows' library may need to update its package.json or typings.