### PR TITLE
Fix: Export default

### DIFF
--- a/dist/wrapper.mjs
+++ b/dist/wrapper.mjs
@@ -1,2 +1,2 @@
 import eiows from './eiows.js'; 
-export { eiows };
+export default eiows;


### PR DESCRIPTION
import eiows from 'eiows'
       ^

SyntaxError: The requested module 'eiows' does not provide an export named 'default'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:134:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:217:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:316:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:123:5)