### PR TITLE
Compression by default on send

### DIFF
--- a/dist/eiows.js
+++ b/dist/eiows.js
@@ -81,11 +81,14 @@ class WebSocket {
                 options = null;
             }
 
-            const binary = options && typeof options.binary === 'boolean' ? options.binary : typeof message !== 'string';
+            const opts = {
+                binary: options && options.binary ? options.binary : typeof message !== 'string',
+                compress: options && options.compress ? options.compress : true,
+            };
 
-            native.server.send(this.external, message, binary ? eiows.OPCODE_BINARY : eiows.OPCODE_TEXT, cb ? (() => {
+            native.server.send(this.external, message, opts.binary ? eiows.OPCODE_BINARY : eiows.OPCODE_TEXT, cb ? (() => {
                 process.nextTick(cb);
-            }) : undefined, options && options.compress);
+            }) : undefined, opts.compress);
         } else if (cb) {
             cb(new Error('not opened'));
         }


### PR DESCRIPTION
In the latest socket.io version I was running into issues whereby the options were never passed into the send() function. The default engine does not exhibit this behaviour due to it's defaulting of compression to on (if the extension is present and if the options are not present).

If compression isn't enabled on the underlying C socket code this will do nothing and thus not break anything.

